### PR TITLE
Add CRUD endpoints for users and roles

### DIFF
--- a/src/controllers/roleController.js
+++ b/src/controllers/roleController.js
@@ -1,0 +1,71 @@
+import { pool } from '../config/db.js';
+
+export const getRoles = async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM roles');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const getRoleById = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const [rows] = await pool.query('SELECT * FROM roles WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'Role not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const createRole = async (req, res) => {
+  const { name, description, is_active } = req.body;
+  if (!name) return res.status(400).json({ message: 'name is required' });
+  try {
+    const [result] = await pool.query(
+      'INSERT INTO roles (name, description, is_active) VALUES (?, ?, ?)',
+      [name, description || null, is_active ?? true]
+    );
+    const [rows] = await pool.query('SELECT * FROM roles WHERE id = ?', [result.insertId]);
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateRole = async (req, res) => {
+  const { id } = req.params;
+  const { name, description, is_active } = req.body;
+  try {
+    const [rows] = await pool.query('SELECT * FROM roles WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'Role not found' });
+    const role = rows[0];
+    await pool.query(
+      'UPDATE roles SET name = ?, description = ?, is_active = ? WHERE id = ?',
+      [name ?? role.name, description ?? role.description, is_active ?? role.is_active, id]
+    );
+    const [updated] = await pool.query('SELECT * FROM roles WHERE id = ?', [id]);
+    res.json(updated[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const deleteRole = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const [rows] = await pool.query('SELECT * FROM roles WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'Role not found' });
+    await pool.query('DELETE FROM roles WHERE id = ?', [id]);
+    res.json({ message: 'Role deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,84 @@
+import bcrypt from 'bcrypt';
+import { pool } from '../config/db.js';
+
+export const getUsers = async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT * FROM users');
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const getUserById = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'User not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const createUser = async (req, res) => {
+  const { username, email, password, rut, role_id, points } = req.body;
+  if (!username || !email || !password)
+    return res.status(400).json({ message: 'username, email and password are required' });
+  try {
+    const passwordHash = await bcrypt.hash(password, 10);
+    const [result] = await pool.query(
+      'INSERT INTO users (username, email, password_hash, rut, role_id, points) VALUES (?, ?, ?, ?, ?, ?)',
+      [username, email, passwordHash, rut || null, role_id || null, points || 0]
+    );
+    const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [result.insertId]);
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateUser = async (req, res) => {
+  const { id } = req.params;
+  const { username, email, password, rut, role_id, points, is_active } = req.body;
+  try {
+    const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'User not found' });
+    const user = rows[0];
+    const passwordHash = password ? await bcrypt.hash(password, 10) : user.password_hash;
+    await pool.query(
+      `UPDATE users SET username = ?, email = ?, password_hash = ?, rut = ?, role_id = ?, points = ?, is_active = ? WHERE id = ?`,
+      [
+        username ?? user.username,
+        email ?? user.email,
+        passwordHash,
+        rut ?? user.rut,
+        role_id ?? user.role_id,
+        points ?? user.points,
+        is_active ?? user.is_active,
+        id
+      ]
+    );
+    const [updated] = await pool.query('SELECT * FROM users WHERE id = ?', [id]);
+    res.json(updated[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const deleteUser = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const [rows] = await pool.query('SELECT * FROM users WHERE id = ?', [id]);
+    if (rows.length === 0) return res.status(404).json({ message: 'User not found' });
+    await pool.query('DELETE FROM users WHERE id = ?', [id]);
+    res.json({ message: 'User deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import express from 'express';
 import authRoutes from './routes/authRoutes.js';
+import userRoutes from './routes/userRoutes.js';
+import roleRoutes from './routes/roleRoutes.js';
 import setupSwagger from './config/swagger.js';
 import dotenv from 'dotenv';
 
@@ -12,6 +14,8 @@ setupSwagger(app);
 app.use(express.json());
 
 app.use('/api/auth', authRoutes);
+app.use('/api/users', userRoutes);
+app.use('/api/roles', roleRoutes);
 
 
 const PORT = process.env.PORT || 3000;

--- a/src/routes/roleRoutes.js
+++ b/src/routes/roleRoutes.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import {
+  getRoles,
+  getRoleById,
+  createRole,
+  updateRole,
+  deleteRole
+} from '../controllers/roleController.js';
+
+const router = express.Router();
+
+router.get('/', getRoles);
+router.get('/:id', getRoleById);
+router.post('/', createRole);
+router.put('/:id', updateRole);
+router.delete('/:id', deleteRole);
+
+export default router;

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import {
+  getUsers,
+  getUserById,
+  createUser,
+  updateUser,
+  deleteUser
+} from '../controllers/userController.js';
+
+const router = express.Router();
+
+router.get('/', getUsers);
+router.get('/:id', getUserById);
+router.post('/', createUser);
+router.put('/:id', updateUser);
+router.delete('/:id', deleteUser);
+
+export default router;


### PR DESCRIPTION
## Summary
- add user and role controllers with CRUD operations
- add routing for new controllers
- register `/api/users` and `/api/roles` in the main app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dbd8a583c832fa2acb9a25313dafe