### PR TITLE
Add CRUD for orders

### DIFF
--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -1,0 +1,60 @@
+import * as orderService from '../services/orderService.js';
+
+export const getOrders = async (req, res) => {
+  try {
+    const orders = await orderService.getAllOrders();
+    res.json(orders);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const getOrderById = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const order = await orderService.getOrderById(id);
+    if (!order) return res.status(404).json({ message: 'Order not found' });
+    res.json(order);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const createOrder = async (req, res) => {
+  const { user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active } = req.body;
+  if (total == null) return res.status(400).json({ message: 'total is required' });
+  try {
+    const order = await orderService.createOrder({ user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active });
+    res.status(201).json(order);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateOrder = async (req, res) => {
+  const { id } = req.params;
+  const { user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active } = req.body;
+  try {
+    const updated = await orderService.updateOrder(id, { user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active });
+    if (!updated) return res.status(404).json({ message: 'Order not found' });
+    res.json(updated);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const deleteOrder = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const deleted = await orderService.deleteOrder(id);
+    if (!deleted) return res.status(404).json({ message: 'Order not found' });
+    res.json({ message: 'Order deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import authRoutes from './routes/authRoutes.js';
 import userRoutes from './routes/userRoutes.js';
 import roleRoutes from './routes/roleRoutes.js';
 import productRoutes from './routes/productRoutes.js';
+import orderRoutes from './routes/orderRoutes.js';
 import setupSwagger from './config/swagger.js';
 import dotenv from 'dotenv';
 
@@ -18,6 +19,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/users', userRoutes);
 app.use('/api/roles', roleRoutes);
 app.use('/api/products', productRoutes);
+app.use('/api/orders', orderRoutes);
 
 
 const PORT = process.env.PORT || 3000;

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import {
+  getOrders,
+  getOrderById,
+  createOrder,
+  updateOrder,
+  deleteOrder
+} from '../controllers/orderController.js';
+
+const router = express.Router();
+
+router.get('/', getOrders);
+router.get('/:id', getOrderById);
+router.post('/', createOrder);
+router.put('/:id', updateOrder);
+router.delete('/:id', deleteOrder);
+
+export default router;

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -1,0 +1,53 @@
+import { pool } from '../config/db.js';
+import { randomUUID } from 'crypto';
+
+export async function getAllOrders() {
+  const [rows] = await pool.query('SELECT * FROM orders');
+  return rows;
+}
+
+export async function getOrderById(id) {
+  const [rows] = await pool.query('SELECT * FROM orders WHERE id = ?', [id]);
+  return rows[0];
+}
+
+export async function createOrder({ user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active }) {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO orders (id, user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, user_id || null, guest_name || null, total, points_used ?? 0, points_earned ?? 0, metodo_pago || null, status || null, order_number || null, is_active ?? true]
+  );
+  const [rows] = await pool.query('SELECT * FROM orders WHERE id = ?', [id]);
+  return rows[0];
+}
+
+export async function updateOrder(id, { user_id, guest_name, total, points_used, points_earned, metodo_pago, status, order_number, is_active }) {
+  const [rows] = await pool.query('SELECT * FROM orders WHERE id = ?', [id]);
+  if (rows.length === 0) return null;
+  const order = rows[0];
+  await pool.query(
+    `UPDATE orders SET user_id = ?, guest_name = ?, total = ?, points_used = ?, points_earned = ?, metodo_pago = ?, status = ?, order_number = ?, is_active = ?, updated_at = NOW() WHERE id = ?`,
+    [
+      user_id ?? order.user_id,
+      guest_name ?? order.guest_name,
+      total ?? order.total,
+      points_used ?? order.points_used,
+      points_earned ?? order.points_earned,
+      metodo_pago ?? order.metodo_pago,
+      status ?? order.status,
+      order_number ?? order.order_number,
+      is_active ?? order.is_active,
+      id
+    ]
+  );
+  const [updated] = await pool.query('SELECT * FROM orders WHERE id = ?', [id]);
+  return updated[0];
+}
+
+export async function deleteOrder(id) {
+  const [rows] = await pool.query('SELECT * FROM orders WHERE id = ?', [id]);
+  if (rows.length === 0) return false;
+  await pool.query('DELETE FROM orders WHERE id = ?', [id]);
+  return true;
+}


### PR DESCRIPTION
## Summary
- create order service with basic queries
- wire controller logic for orders
- expose order endpoints
- register order routes in the app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e17a59d78832fb1fbaed8f0bc568d