### PR TITLE
Restrict user creation to admin role

### DIFF
--- a/src/middlewares/roleMiddleware.js
+++ b/src/middlewares/roleMiddleware.js
@@ -1,8 +1,9 @@
 export const tieneRol = (...rolesPermitidos) => {
   return (req, res, next) => {
-    const { rol } = req.user;
+    // El token puede incluir la propiedad `rol` (nombre del rol) o `role_id`.
+    const rolActual = req.user?.rol ?? req.user?.role_id;
 
-    if (!rolesPermitidos.includes(rol)) {
+    if (!rolesPermitidos.includes(rolActual)) {
       return res.status(403).json({ message: 'No tienes permiso para realizar esta acción' });
     }
     next();

--- a/src/routes/userRoutes.js
+++ b/src/routes/userRoutes.js
@@ -7,6 +7,7 @@ import {
   deleteUser
 } from '../controllers/userController.js';
 import { verificarToken } from '../middlewares/authMiddleware.js';
+import { tieneRol } from '../middlewares/roleMiddleware.js';
 
 const router = express.Router();
 
@@ -14,7 +15,7 @@ router.use(verificarToken);
 
 router.get('/', getUsers);
 router.get('/:id', getUserById);
-router.post('/', createUser);
+router.post('/', tieneRol('admin'), createUser);
 router.put('/:id', updateUser);
 router.delete('/:id', deleteUser);
 


### PR DESCRIPTION
## Summary
- add flexible role middleware supporting `rol` or `role_id`
- restrict POST `/api/users` with the new middleware
- include role name in auth tokens and responses

## Testing
- `npm test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6861efa1d1d8832f97a7399183acb904