### PR TITLE
Add endpoint for daily sales totals

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,2 +1,7 @@
 # Pedidos Churros Cuchito Backend
 Este proyecto usa Express y ahora tiene habilitado CORS.
+
+## Endpoints adicionales
+
+- `GET /api/orders/total-por-dia?fecha=AAAA-MM-DD` retorna el total de ventas
+  por método de pago (efectivo o tarjeta) para la fecha indicada.

--- a/README.MD
+++ b/README.MD
@@ -5,3 +5,6 @@ Este proyecto usa Express y ahora tiene habilitado CORS.
 
 - `GET /api/orders/total-por-dia?fecha=AAAA-MM-DD` retorna el total de ventas
   por método de pago (efectivo o tarjeta) para la fecha indicada.
+- `POST /api/cierres-caja/generar` genera un cierre de caja para la fecha indicada
+  combinando datos enviados por el usuario con los montos calculados a partir de
+  las órdenes del día.

--- a/src/controllers/cierreCajaController.js
+++ b/src/controllers/cierreCajaController.js
@@ -119,3 +119,36 @@ export const deleteCierreCaja = async (req, res) => {
     res.status(500).json({ message: 'Server error' });
   }
 };
+
+export const generateCierreCaja = async (req, res) => {
+  const {
+    fecha,
+    maquina1,
+    pedidos_ya,
+    salidas_efectivo,
+    ingresos_efectivo,
+    usuario_id,
+    observacion,
+    is_active
+  } = req.body;
+
+  if (!fecha || !usuario_id) {
+    return res.status(400).json({ message: 'fecha and usuario_id are required' });
+  }
+  try {
+    const cierre = await cierreCajaService.generateCierreCaja({
+      fecha,
+      maquina1,
+      pedidos_ya,
+      salidas_efectivo,
+      ingresos_efectivo,
+      usuario_id,
+      observacion,
+      is_active
+    });
+    res.status(201).json(cierre);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/controllers/orderController.js
+++ b/src/controllers/orderController.js
@@ -23,6 +23,18 @@ export const getOrderById = async (req, res) => {
   }
 };
 
+export const getTotalPorDia = async (req, res) => {
+  const { fecha } = req.query;
+  if (!fecha) return res.status(400).json({ message: 'fecha is required' });
+  try {
+    const totals = await orderService.getTotalByDate(fecha);
+    res.json(totals);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
 export const downloadOrderPDF = async (req, res) => {
   const { orderId } = req.params;
   const categoria = (req.query.categoria || '').toLowerCase(); // 'churros' o 'otros'

--- a/src/routes/cierreCajaRoutes.js
+++ b/src/routes/cierreCajaRoutes.js
@@ -4,7 +4,8 @@ import {
   getCierreCajaById,
   createCierreCaja,
   updateCierreCaja,
-  deleteCierreCaja
+  deleteCierreCaja,
+  generateCierreCaja
 } from '../controllers/cierreCajaController.js';
 import { verificarToken } from '../middlewares/authMiddleware.js';
 
@@ -15,6 +16,7 @@ router.use(verificarToken);
 router.get('/', getCierresCaja);
 router.get('/:id', getCierreCajaById);
 router.post('/', createCierreCaja);
+router.post('/generar', generateCierreCaja);
 router.put('/:id', updateCierreCaja);
 router.delete('/:id', deleteCierreCaja);
 

--- a/src/routes/orderRoutes.js
+++ b/src/routes/orderRoutes.js
@@ -2,6 +2,7 @@ import express from 'express';
 import {
   getOrders,
   getOrderById,
+  getTotalPorDia,
   downloadOrderPDF,
   createOrder,
   updateOrder,
@@ -14,6 +15,7 @@ const router = express.Router();
 router.use(verificarToken);
 
 router.get('/', getOrders);
+router.get('/total-por-dia', getTotalPorDia);
 router.get('/:orderId/pdf', downloadOrderPDF);
 router.get('/:id', getOrderById);
 router.post('/', createOrder);

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -86,3 +86,18 @@ export async function deleteOrder(id) {
   await pool.query('DELETE FROM orders WHERE id = ?', [id]);
   return true;
 }
+
+export async function getTotalByDate(fecha) {
+  const [rows] = await pool.query(
+    `SELECT
+      DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago')) AS fecha,
+      metodo_pago,
+      FORMAT(SUM(total), 2) AS total_por_dia
+     FROM orders
+     WHERE DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago')) = ?
+     GROUP BY fecha, metodo_pago
+     ORDER BY fecha DESC, metodo_pago`,
+    [fecha]
+  );
+  return rows;
+}

--- a/src/services/orderService.js
+++ b/src/services/orderService.js
@@ -90,14 +90,15 @@ export async function deleteOrder(id) {
 export async function getTotalByDate(fecha) {
   const [rows] = await pool.query(
     `SELECT
-      DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago')) AS fecha,
-      metodo_pago,
-      FORMAT(SUM(total), 2) AS total_por_dia
+       DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago')) AS fecha,
+       metodo_pago,
+       FORMAT(SUM(total), 2) AS total_por_dia
      FROM orders
-     WHERE DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago')) = ?
+     WHERE DATE(CONVERT_TZ(created_at, 'UTC', 'America/Santiago'))
+           BETWEEN ? AND ?
      GROUP BY fecha, metodo_pago
      ORDER BY fecha DESC, metodo_pago`,
-    [fecha]
+    [fecha, fecha]
   );
   return rows;
 }


### PR DESCRIPTION
## Summary
- add `getTotalByDate` service to compute totals by payment method
- expose controller and route for `GET /api/orders/total-por-dia`
- document new endpoint in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c33c3a214832f9e02d400301e11be