### PR TITLE
Add closure generation using totals

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -5,3 +5,6 @@ Este proyecto usa Express y ahora tiene habilitado CORS.
 
 - `GET /api/orders/total-por-dia?fecha=AAAA-MM-DD` retorna el total de ventas
   por método de pago (efectivo o tarjeta) para la fecha indicada.
+- `POST /api/cierres-caja/generar` genera un cierre de caja para la fecha indicada
+  combinando datos enviados por el usuario con los montos calculados a partir de
+  las órdenes del día.

--- a/src/controllers/cierreCajaController.js
+++ b/src/controllers/cierreCajaController.js
@@ -119,3 +119,36 @@ export const deleteCierreCaja = async (req, res) => {
     res.status(500).json({ message: 'Server error' });
   }
 };
+
+export const generateCierreCaja = async (req, res) => {
+  const {
+    fecha,
+    maquina1,
+    pedidos_ya,
+    salidas_efectivo,
+    ingresos_efectivo,
+    usuario_id,
+    observacion,
+    is_active
+  } = req.body;
+
+  if (!fecha || !usuario_id) {
+    return res.status(400).json({ message: 'fecha and usuario_id are required' });
+  }
+  try {
+    const cierre = await cierreCajaService.generateCierreCaja({
+      fecha,
+      maquina1,
+      pedidos_ya,
+      salidas_efectivo,
+      ingresos_efectivo,
+      usuario_id,
+      observacion,
+      is_active
+    });
+    res.status(201).json(cierre);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/routes/cierreCajaRoutes.js
+++ b/src/routes/cierreCajaRoutes.js
@@ -4,7 +4,8 @@ import {
   getCierreCajaById,
   createCierreCaja,
   updateCierreCaja,
-  deleteCierreCaja
+  deleteCierreCaja,
+  generateCierreCaja
 } from '../controllers/cierreCajaController.js';
 import { verificarToken } from '../middlewares/authMiddleware.js';
 
@@ -15,6 +16,7 @@ router.use(verificarToken);
 router.get('/', getCierresCaja);
 router.get('/:id', getCierreCajaById);
 router.post('/', createCierreCaja);
+router.post('/generar', generateCierreCaja);
 router.put('/:id', updateCierreCaja);
 router.delete('/:id', deleteCierreCaja);
 


### PR DESCRIPTION
## Summary
- compute totals for cierre de caja using existing order totals
- expose endpoint to generate cierre de caja automatically
- document new endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687c408ba450832fa11c1752d25bc432