### PR TITLE
Implement informes cierres caja CRUD

### DIFF
--- a/src/controllers/cierreCajaController.js
+++ b/src/controllers/cierreCajaController.js
@@ -39,13 +39,10 @@ export const createCierreCaja = async (req, res) => {
     fecha,
     total_efectivo,
     total_maquinas,
-    maquina1,
-    pedidos_ya,
     salidas_efectivo,
     ingresos_efectivo,
     usuario_id,
     observacion,
-    total_pagos_tarjeta_web,
     is_active
   } = req.body;
 
@@ -53,12 +50,9 @@ export const createCierreCaja = async (req, res) => {
     !fecha ||
     total_efectivo == null ||
     total_maquinas == null ||
-    maquina1 == null ||
-    pedidos_ya == null ||
     salidas_efectivo == null ||
     ingresos_efectivo == null ||
-    !usuario_id ||
-    total_pagos_tarjeta_web == null
+    !usuario_id
   ) {
     return res.status(400).json({ message: 'Missing required fields' });
   }
@@ -67,13 +61,10 @@ export const createCierreCaja = async (req, res) => {
       fecha,
       total_efectivo,
       total_maquinas,
-      maquina1,
-      pedidos_ya,
       salidas_efectivo,
       ingresos_efectivo,
       usuario_id,
       observacion,
-      total_pagos_tarjeta_web,
       is_active
     });
     res.status(201).json(cierre);
@@ -89,13 +80,10 @@ export const updateCierreCaja = async (req, res) => {
     fecha,
     total_efectivo,
     total_maquinas,
-    maquina1,
-    pedidos_ya,
     salidas_efectivo,
     ingresos_efectivo,
     usuario_id,
     observacion,
-    total_pagos_tarjeta_web,
     is_active
   } = req.body;
   try {
@@ -103,13 +91,10 @@ export const updateCierreCaja = async (req, res) => {
       fecha,
       total_efectivo,
       total_maquinas,
-      maquina1,
-      pedidos_ya,
       salidas_efectivo,
       ingresos_efectivo,
       usuario_id,
       observacion,
-      total_pagos_tarjeta_web,
       is_active
     });
     if (!updated) return res.status(404).json({ message: 'Cierre de caja not found' });
@@ -135,8 +120,9 @@ export const deleteCierreCaja = async (req, res) => {
 export const generateCierreCaja = async (req, res) => {
   const {
     fecha,
-    maquina1,
-    pedidos_ya,
+    monto_declarado_efectivo,
+    monto_declarado_tarjeta,
+    monto_declarado_pedidos_ya,
     salidas_efectivo,
     ingresos_efectivo,
     usuario_id,
@@ -144,14 +130,15 @@ export const generateCierreCaja = async (req, res) => {
     is_active
   } = req.body;
 
-  if (!fecha || !usuario_id) {
+  if (!fecha || !usuario_id || monto_declarado_efectivo == null || monto_declarado_tarjeta == null || monto_declarado_pedidos_ya == null) {
     return res.status(400).json({ message: 'fecha and usuario_id are required' });
   }
   try {
     const cierre = await cierreCajaService.generateCierreCaja({
       fecha,
-      maquina1,
-      pedidos_ya,
+      monto_declarado_efectivo,
+      monto_declarado_tarjeta,
+      monto_declarado_pedidos_ya,
       salidas_efectivo,
       ingresos_efectivo,
       usuario_id,

--- a/src/controllers/informesCierreCajaController.js
+++ b/src/controllers/informesCierreCajaController.js
@@ -1,0 +1,80 @@
+import * as informeService from '../services/informesCierreCajaService.js';
+
+export const getInformesCierreCaja = async (req, res) => {
+  try {
+    const informes = await informeService.getAllInformesCierreCaja();
+    res.json(informes);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const getInformeCierreCajaById = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const informe = await informeService.getInformeCierreCajaById(id);
+    if (!informe) return res.status(404).json({ message: 'Informe not found' });
+    res.json(informe);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const createInformeCierreCaja = async (req, res) => {
+  const { monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id } = req.body;
+  if (
+    monto_declarado_efectivo == null ||
+    monto_declarado_tarjeta == null ||
+    monto_declarado_pedidos_ya == null ||
+    !fecha ||
+    !cierre_caja_id
+  ) {
+    return res.status(400).json({ message: 'Missing required fields' });
+  }
+  try {
+    const informe = await informeService.createInformeCierreCaja({
+      monto_declarado_efectivo,
+      monto_declarado_tarjeta,
+      monto_declarado_pedidos_ya,
+      fecha,
+      cierre_caja_id
+    });
+    res.status(201).json(informe);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const updateInformeCierreCaja = async (req, res) => {
+  const { id } = req.params;
+  const { monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id } = req.body;
+  try {
+    const updated = await informeService.updateInformeCierreCaja(id, {
+      monto_declarado_efectivo,
+      monto_declarado_tarjeta,
+      monto_declarado_pedidos_ya,
+      fecha,
+      cierre_caja_id
+    });
+    if (!updated) return res.status(404).json({ message: 'Informe not found' });
+    res.json(updated);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};
+
+export const deleteInformeCierreCaja = async (req, res) => {
+  const { id } = req.params;
+  try {
+    const deleted = await informeService.deleteInformeCierreCaja(id);
+    if (!deleted) return res.status(404).json({ message: 'Informe not found' });
+    res.json({ message: 'Informe deleted' });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Server error' });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import productRoutes from './routes/productRoutes.js';
 import orderRoutes from './routes/orderRoutes.js';
 import orderItemRoutes from './routes/orderItemRoutes.js';
 import cierreCajaRoutes from './routes/cierreCajaRoutes.js';
+import informesCierreCajaRoutes from './routes/informesCierreCajaRoutes.js';
 import setupSwagger from './config/swagger.js';
 import dotenv from 'dotenv';
 
@@ -26,6 +27,7 @@ app.use('/api/products', productRoutes);
 app.use('/api/orders', orderRoutes);
 app.use('/api/order-items', orderItemRoutes);
 app.use('/api/cierres-caja', cierreCajaRoutes);
+app.use('/api/informes-cierres-caja', informesCierreCajaRoutes);
 
 
 const PORT = process.env.PORT || 3000;

--- a/src/routes/informesCierreCajaRoutes.js
+++ b/src/routes/informesCierreCajaRoutes.js
@@ -1,0 +1,21 @@
+import express from 'express';
+import {
+  getInformesCierreCaja,
+  getInformeCierreCajaById,
+  createInformeCierreCaja,
+  updateInformeCierreCaja,
+  deleteInformeCierreCaja
+} from '../controllers/informesCierreCajaController.js';
+import { verificarToken } from '../middlewares/authMiddleware.js';
+
+const router = express.Router();
+
+router.use(verificarToken);
+
+router.get('/', getInformesCierreCaja);
+router.get('/:id', getInformeCierreCajaById);
+router.post('/', createInformeCierreCaja);
+router.put('/:id', updateInformeCierreCaja);
+router.delete('/:id', deleteInformeCierreCaja);
+
+export default router;

--- a/src/services/cierreCajaService.js
+++ b/src/services/cierreCajaService.js
@@ -1,6 +1,7 @@
 import { pool } from '../config/db.js';
 import { randomUUID } from 'crypto';
 import { getTotalByDate } from './orderService.js';
+import { createInformeCierreCaja } from './informesCierreCajaService.js';
 
 export async function getAllCierresCaja() {
   const [rows] = await pool.query('SELECT * FROM cierres_caja');
@@ -21,34 +22,31 @@ export async function getCierreCajaByDate(fecha) {
   return rows[0] || null; 
 }
 
-export async function createCierreCaja({ fecha, total_efectivo, total_maquinas, maquina1, pedidos_ya, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, total_pagos_tarjeta_web, is_active }) {
+export async function createCierreCaja({ fecha, total_efectivo, total_maquinas, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, is_active }) {
   const id = randomUUID();
   await pool.query(
-    `INSERT INTO cierres_caja (id, fecha, total_efectivo, total_maquinas, maquina1, pedidos_ya, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, total_pagos_tarjeta_web, is_active)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [id, fecha, total_efectivo, total_maquinas, maquina1, pedidos_ya, salidas_efectivo, ingresos_efectivo, usuario_id, observacion || null, total_pagos_tarjeta_web, is_active ?? true]
+    `INSERT INTO cierres_caja (id, fecha, total_efectivo, total_maquinas, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, is_active)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [id, fecha, total_efectivo, total_maquinas, salidas_efectivo, ingresos_efectivo, usuario_id, observacion || null, is_active ?? true]
   );
   const [rows] = await pool.query('SELECT * FROM cierres_caja WHERE id = ?', [id]);
   return rows[0];
 }
 
-export async function updateCierreCaja(id, { fecha, total_efectivo, total_maquinas, maquina1, pedidos_ya, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, total_pagos_tarjeta_web, is_active }) {
+export async function updateCierreCaja(id, { fecha, total_efectivo, total_maquinas, salidas_efectivo, ingresos_efectivo, usuario_id, observacion, is_active }) {
   const [rows] = await pool.query('SELECT * FROM cierres_caja WHERE id = ?', [id]);
   if (rows.length === 0) return null;
   const cierre = rows[0];
   await pool.query(
-    `UPDATE cierres_caja SET fecha = ?, total_efectivo = ?, total_maquinas = ?, maquina1 = ?, pedidos_ya = ?, salidas_efectivo = ?, ingresos_efectivo = ?, usuario_id = ?, observacion = ?, total_pagos_tarjeta_web = ?, is_active = ?, updated_at = NOW() WHERE id = ?`,
+    `UPDATE cierres_caja SET fecha = ?, total_efectivo = ?, total_maquinas = ?, salidas_efectivo = ?, ingresos_efectivo = ?, usuario_id = ?, observacion = ?, is_active = ?, updated_at = NOW() WHERE id = ?`,
     [
       fecha ?? cierre.fecha,
       total_efectivo ?? cierre.total_efectivo,
       total_maquinas ?? cierre.total_maquinas,
-      maquina1 ?? cierre.maquina1,
-      pedidos_ya ?? cierre.pedidos_ya,
       salidas_efectivo ?? cierre.salidas_efectivo,
       ingresos_efectivo ?? cierre.ingresos_efectivo,
       usuario_id ?? cierre.usuario_id,
       observacion ?? cierre.observacion,
-      total_pagos_tarjeta_web ?? cierre.total_pagos_tarjeta_web,
       is_active ?? cierre.is_active,
       id
     ]
@@ -66,8 +64,9 @@ export async function deleteCierreCaja(id) {
 
 export async function generateCierreCaja({
   fecha,
-  maquina1,
-  pedidos_ya,
+  monto_declarado_efectivo,
+  monto_declarado_tarjeta,
+  monto_declarado_pedidos_ya,
   salidas_efectivo,
   ingresos_efectivo,
   usuario_id,
@@ -77,32 +76,35 @@ export async function generateCierreCaja({
   const totals = await getTotalByDate(fecha);
   let totalEfectivo = 0;
   let totalMaquinas = 0;
-  let totalWeb = 0;
 
   for (const t of totals) {
     const metodo = (t.metodo_pago || '').toLowerCase();
     const monto = parseFloat(String(t.total_por_dia).replace(/,/g, '')) || 0;
     if (metodo.includes('efectivo')) {
       totalEfectivo += monto;
-    } else if (metodo.includes('web')) {
-      totalWeb += monto;
-      totalMaquinas += monto;
     } else {
       totalMaquinas += monto;
     }
   }
 
-  return createCierreCaja({
+  const cierre = await createCierreCaja({
     fecha,
     total_efectivo: totalEfectivo,
     total_maquinas: totalMaquinas,
-    maquina1: maquina1 ?? 0,
-    pedidos_ya: pedidos_ya ?? 0,
     salidas_efectivo: salidas_efectivo ?? 0,
     ingresos_efectivo: ingresos_efectivo ?? 0,
     usuario_id,
     observacion,
-    total_pagos_tarjeta_web: totalWeb,
     is_active
   });
+
+  await createInformeCierreCaja({
+    monto_declarado_efectivo,
+    monto_declarado_tarjeta,
+    monto_declarado_pedidos_ya,
+    fecha,
+    cierre_caja_id: cierre.id
+  });
+
+  return cierre;
 }

--- a/src/services/informesCierreCajaService.js
+++ b/src/services/informesCierreCajaService.js
@@ -1,0 +1,49 @@
+import { pool } from '../config/db.js';
+import { randomUUID } from 'crypto';
+
+export async function getAllInformesCierreCaja() {
+  const [rows] = await pool.query('SELECT * FROM informes_cierres_caja');
+  return rows;
+}
+
+export async function getInformeCierreCajaById(id) {
+  const [rows] = await pool.query('SELECT * FROM informes_cierres_caja WHERE id = ?', [id]);
+  return rows[0];
+}
+
+export async function createInformeCierreCaja({ monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id }) {
+  const id = randomUUID();
+  await pool.query(
+    `INSERT INTO informes_cierres_caja (id, monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id)` +
+      ` VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id]
+  );
+  const [rows] = await pool.query('SELECT * FROM informes_cierres_caja WHERE id = ?', [id]);
+  return rows[0];
+}
+
+export async function updateInformeCierreCaja(id, { monto_declarado_efectivo, monto_declarado_tarjeta, monto_declarado_pedidos_ya, fecha, cierre_caja_id }) {
+  const [rows] = await pool.query('SELECT * FROM informes_cierres_caja WHERE id = ?', [id]);
+  if (rows.length === 0) return null;
+  const informe = rows[0];
+  await pool.query(
+    `UPDATE informes_cierres_caja SET monto_declarado_efectivo = ?, monto_declarado_tarjeta = ?, monto_declarado_pedidos_ya = ?, fecha = ?, cierre_caja_id = ?, updated_at = NOW() WHERE id = ?`,
+    [
+      monto_declarado_efectivo ?? informe.monto_declarado_efectivo,
+      monto_declarado_tarjeta ?? informe.monto_declarado_tarjeta,
+      monto_declarado_pedidos_ya ?? informe.monto_declarado_pedidos_ya,
+      fecha ?? informe.fecha,
+      cierre_caja_id ?? informe.cierre_caja_id,
+      id
+    ]
+  );
+  const [updated] = await pool.query('SELECT * FROM informes_cierres_caja WHERE id = ?', [id]);
+  return updated[0];
+}
+
+export async function deleteInformeCierreCaja(id) {
+  const [rows] = await pool.query('SELECT * FROM informes_cierres_caja WHERE id = ?', [id]);
+  if (rows.length === 0) return false;
+  await pool.query('DELETE FROM informes_cierres_caja WHERE id = ?', [id]);
+  return true;
+}


### PR DESCRIPTION
## Summary
- add CRUD logic for `informes_cierres_caja`
- update cierre de caja services and controller to new DB schema
- make `generateCierreCaja` also create an `informes_cierres_caja` record
- register new routes in the API

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687fe02c0700832fbaf0f7d478cdabca